### PR TITLE
Workaround for OpenCL API issue Mali-G610 MP4 GPU

### DIFF
--- a/src/Kernel.cpp
+++ b/src/Kernel.cpp
@@ -36,20 +36,12 @@ Kernel::Kernel(cl_kernel kernel_, bool with_arg_map)
 		}
 
 		for(cl_uint i = 0; i < num_args; ++i) {
-			if(cl_int err = clGetKernelArgInfo(kernel, i, CL_KERNEL_ARG_NAME, 0, 0, &length)) {
-				throw opencl_error_t("clGetKernelArgInfo(CL_KERNEL_ARG_NAME, 0, 0) failed with " + get_error_string(err));
+			char paramv[256];
+			if(cl_int err = clGetKernelArgInfo(kernel, i, CL_KERNEL_ARG_NAME, sizeof(paramv), &paramv, &length)) {
+				throw opencl_error_t("clGetKernelArgInfo(CL_KERNEL_ARG_NAME, tmpbufsize, tmpbuf) failed with " + get_error_string(err));
 			}
-
-			// OpenCL <= 2.1, not required to return bytes needed, only bytes copied
 			if(!length) {
-				char paramv[256];
-				if(cl_int err = clGetKernelArgInfo(kernel, i, CL_KERNEL_ARG_NAME, sizeof(paramv), &paramv, &length)) {
-					throw opencl_error_t("clGetKernelArgInfo(CL_KERNEL_ARG_NAME, tmpsize, tmpbuf) failed with " + get_error_string(err));
-				}
-			}
-
-			if(!length) {
-				throw std::runtime_error("kernel argument name too short");
+				throw std::runtime_error("kernel argument name too short or buffer too small");
 			}
 			std::string arg;
 			arg.resize(length);

--- a/src/Kernel.cpp
+++ b/src/Kernel.cpp
@@ -36,21 +36,15 @@ Kernel::Kernel(cl_kernel kernel_, bool with_arg_map)
 		}
 
 		for(cl_uint i = 0; i < num_args; ++i) {
-			char paramv[256];
-			if(cl_int err = clGetKernelArgInfo(kernel, i, CL_KERNEL_ARG_NAME, sizeof(paramv), &paramv, &length)) {
-				throw opencl_error_t("clGetKernelArgInfo(CL_KERNEL_ARG_NAME, tmpbufsize, tmpbuf) failed with " + get_error_string(err));
+			std::string arg;
+			arg.resize(256);
+			if(cl_int err = clGetKernelArgInfo(kernel, i, CL_KERNEL_ARG_NAME, arg.size(), &arg[0], &length)) {
+				throw opencl_error_t("clGetKernelArgInfo(CL_KERNEL_ARG_NAME) failed with " + get_error_string(err));
 			}
 			if(!length) {
 				throw std::runtime_error("kernel argument name too short or buffer too small");
 			}
-			std::string arg;
-			arg.resize(length);
-			if(cl_int err = clGetKernelArgInfo(kernel, i, CL_KERNEL_ARG_NAME, arg.size(), &arg[0], &length)) {
-				throw opencl_error_t("clGetKernelArgInfo(CL_KERNEL_ARG_NAME) failed with " + get_error_string(err));
-			}
-			if(length) {
-				arg.resize(length - 1);
-			}
+			arg.resize(length - 1);
 			arg_list.push_back(arg);
 			arg_map[arg] = i;
 		}

--- a/src/Kernel.cpp
+++ b/src/Kernel.cpp
@@ -39,6 +39,17 @@ Kernel::Kernel(cl_kernel kernel_, bool with_arg_map)
 			if(cl_int err = clGetKernelArgInfo(kernel, i, CL_KERNEL_ARG_NAME, 0, 0, &length)) {
 				throw opencl_error_t("clGetKernelArgInfo(CL_KERNEL_ARG_NAME, 0, 0) failed with " + get_error_string(err));
 			}
+
+			// workaround for API issue observed with ROCK 5B, Mali-G610 MP4 GPU, OpenCL implementation
+			// CL_KERNEL_ARG_NAME, param_value_size=0, param_value=NULL, always 0 in param_value_size_ret
+			// if detected, try fallback with big enough temp buffer, to find size
+			if(!length) {
+				char paramv[256];
+				if(cl_int err = clGetKernelArgInfo(kernel, i, CL_KERNEL_ARG_NAME, sizeof(paramv), &paramv, &length)) {
+					throw opencl_error_t("clGetKernelArgInfo(CL_KERNEL_ARG_NAME, tmpsize, tmpbuf) failed with " + get_error_string(err));
+				}
+			}
+
 			if(!length) {
 				throw std::runtime_error("kernel argument name too short");
 			}

--- a/src/Kernel.cpp
+++ b/src/Kernel.cpp
@@ -40,9 +40,7 @@ Kernel::Kernel(cl_kernel kernel_, bool with_arg_map)
 				throw opencl_error_t("clGetKernelArgInfo(CL_KERNEL_ARG_NAME, 0, 0) failed with " + get_error_string(err));
 			}
 
-			// workaround for API issue observed with ROCK 5B, Mali-G610 MP4 GPU, OpenCL implementation
-			// CL_KERNEL_ARG_NAME, param_value_size=0, param_value=NULL, always 0 in param_value_size_ret
-			// if detected, try fallback with big enough temp buffer, to find size
+			// OpenCL <= 2.1, not required to return bytes needed, only bytes copied
 			if(!length) {
 				char paramv[256];
 				if(cl_int err = clGetKernelArgInfo(kernel, i, CL_KERNEL_ARG_NAME, sizeof(paramv), &paramv, &length)) {


### PR DESCRIPTION
PR for workaround for **API issue** observed with ROCK 5B, **Mali-G610 MP4 GPU**, **OpenCL implementation**.

**Goal:** Fix an OpenCL API issue with Mali-G610 MP4 GPU.

Issue:
- On ROCK 5B (ARM/RK3588 SBC), w/Mali-G610 MP4 GPU
- Ubuntu 22.04 (image from [ubuntu-rockchip](https://github.com/Joshua-Riek/ubuntu-rockchip))
- Trying to use GPU with [mmx-node](https://github.com/madMAx43v3r/mmx-node)
- Following error: `[Node] WARN: Failed to create OpenCL GPU context: kernel argument name too short`

Cause:
- Calling [clGetKernelArgInfo](https://registry.khronos.org/OpenCL/sdk/3.0/docs/man/html/clGetKernelArgInfo.html) ([CL_KERNEL_ARG_NAME](https://registry.khronos.org/OpenCL/specs/3.0-unified/html/OpenCL_API.html#CL_KERNEL_ARG_NAME))
- `param_value_size_ret` always 0, if input `param_value_size=0` and `param_value=0/NULL`

Workaround:
- If `(!length)`
- Try once more, with temp 256 bytes buffer/size
- Getting name/length works, if enough size

Thoughts:
- Might be unique to this platform (only observed here).
- Others looks to (as is customary) return required length, if not enough space in buffer.
- Not important platform to support (Mali-G610 MP4 GPU, really really weak/useless compute).
- Mostly wanted to PR it for future reference (if happens again/other places).

You choose merge or close. Happy either way.
